### PR TITLE
Reference computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ members = [
     "primitives/poseidon"
 ]
 
+exclude = [
+    "sha-reference",
+]
+
 [profile.dev]
 opt-level = 3
 

--- a/sha-reference/Cargo.toml
+++ b/sha-reference/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "sha-reference"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/sha-reference/src/lib.rs
+++ b/sha-reference/src/lib.rs
@@ -1,0 +1,1 @@
+mod word;

--- a/sha-reference/src/lib.rs
+++ b/sha-reference/src/lib.rs
@@ -41,3 +41,40 @@ pub fn sha<const L: usize>(input: Octet<L>) -> Octet<L> {
 
     output
 }
+
+#[cfg(test)]
+mod tests{
+    use crate::{Octet, Word};
+    use crate::word::Bit::{One, Zero};
+
+    /// Test input on 2-bit words:
+    /// a: 00, b: 01, c: 10, d: 11, e: 00, f: 01, g: 10, h: 11
+    #[test]
+    fn test_single_round() {
+        let input = Octet {
+            a: Word::from([Zero, Zero]),
+            b: Word::from([Zero, One]),
+            c: Word::from([One, Zero]),
+            d: Word::from([One, One]),
+            e: Word::from([Zero, Zero]),
+            f: Word::from([Zero, One]),
+            g: Word::from([One, Zero]),
+            h: Word::from([One, One]),
+        };
+
+        let expected = Octet {
+            b: Word::from([Zero, Zero]), // copied a
+            c: Word::from([Zero, One]),  // copied b
+            d: Word::from([One, Zero]),  // copied c
+            f: Word::from([Zero, Zero]), // copied e
+            g: Word::from([Zero, One]),  // copied f
+            h: Word::from([One, Zero]),  // copied g
+
+            e: Word::from([One, Zero]),  // d + h + e.rot_1() + choose(e, f, g)
+            a: Word::from([Zero, One]),  //     h + e.rot_1() + choose(e, f, g) + a.rot_0() + majority(a, b, c)
+        };
+
+        let output = super::sha_round(input);
+        assert_eq!(output, expected);
+    }
+}

--- a/sha-reference/src/lib.rs
+++ b/sha-reference/src/lib.rs
@@ -31,3 +31,13 @@ pub fn sha_round<const L: usize>(input: Octet<L>) -> Octet<L> {
 
     output
 }
+
+pub fn sha<const L: usize>(input: Octet<L>) -> Octet<L> {
+    let mut output = input;
+
+    for _ in 0..64 {
+        output = sha_round(output);
+    }
+
+    output
+}

--- a/sha-reference/src/lib.rs
+++ b/sha-reference/src/lib.rs
@@ -1,1 +1,33 @@
+pub use crate::word::Word;
+use crate::word::{choose, majority};
+
 mod word;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Octet<const L: usize> {
+    a: Word<L>,
+    b: Word<L>,
+    c: Word<L>,
+    d: Word<L>,
+    e: Word<L>,
+    f: Word<L>,
+    g: Word<L>,
+    h: Word<L>,
+}
+
+pub fn sha_round<const L: usize>(input: Octet<L>) -> Octet<L> {
+    let mut output = input;
+
+    output.b = input.a;
+    output.c = input.b;
+    output.d = input.c;
+    output.f = input.e;
+    output.g = input.f;
+    output.h = input.g;
+
+    let temp = input.h + input.e.rot_1() + choose(&input.e, &input.f, &input.g);
+    output.e = input.d + temp;
+    output.a = temp + input.a.rot_0() + majority(&input.a, &input.b, &input.c);
+
+    output
+}

--- a/sha-reference/src/word.rs
+++ b/sha-reference/src/word.rs
@@ -34,7 +34,7 @@ impl<const L: usize> Word<L> {
         }
     }
 
-    pub fn right_rotation(&self, n: usize) -> Self {
+    fn right_rotation(&self, n: usize) -> Self {
         let mut result = Self::zero();
         for i in 0..L {
             result[i] = self[(i + n * L - n) % L];

--- a/sha-reference/src/word.rs
+++ b/sha-reference/src/word.rs
@@ -29,7 +29,9 @@ pub type Limb<const L: usize> = Word<L>;
 
 impl<const L: usize> Word<L> {
     pub fn zero() -> Self {
-        Self { bits: [Bit::Zero; L] }
+        Self {
+            bits: [Bit::Zero; L],
+        }
     }
 
     pub fn right_rotation(&self, n: usize) -> Self {

--- a/sha-reference/src/word.rs
+++ b/sha-reference/src/word.rs
@@ -1,0 +1,100 @@
+#![allow(unused)]
+
+use std::ops::{Add, BitXor};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Default)]
+pub enum Bit {
+    #[default]
+    Zero,
+    One,
+}
+
+impl Add for Bit {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Bit::Zero, Bit::Zero) | (Bit::One, Bit::One) => Bit::Zero,
+            _ => Bit::One,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Word<const L: usize> {
+    bits: [Bit; L],
+}
+
+pub type Limb<const L: usize> = Word<L>;
+
+impl<const L: usize> Word<L> {
+    pub fn zero() -> Self {
+        Self { bits: [Bit::Zero; L] }
+    }
+
+    pub fn right_rotation(&self, n: usize) -> Self {
+        let mut result = Self::zero();
+        for i in 0..L {
+            result.bits[i] = self.bits[(i + L - n) % L];
+        }
+        result
+    }
+
+    pub fn rot_0(&self) -> Self {
+        self.right_rotation(2) ^ self.right_rotation(13) ^ self.right_rotation(22)
+    }
+
+    pub fn rot_1(&self) -> Self {
+        self.right_rotation(6) ^ self.right_rotation(11) ^ self.right_rotation(25)
+    }
+}
+
+pub fn majority<const L: usize>(a: &Word<L>, b: &Word<L>, c: &Word<L>) -> Word<L> {
+    let mut result = Word::zero();
+    for i in 0..L {
+        result.bits[i] = match (a.bits[i], b.bits[i], c.bits[i]) {
+            (Bit::Zero, Bit::Zero, Bit::Zero)
+            | (Bit::Zero, Bit::Zero, Bit::One)
+            | (Bit::Zero, Bit::One, Bit::Zero)
+            | (Bit::One, Bit::Zero, Bit::Zero) => Bit::Zero,
+            _ => Bit::One,
+        };
+    }
+    result
+}
+
+pub fn choose<const L: usize>(a: &Word<L>, b: &Word<L>, c: &Word<L>) -> Word<L> {
+    let mut result = Word::zero();
+    for i in 0..L {
+        let (r#if, then, r#else) = (a.bits[i], b.bits[i], c.bits[i]);
+        result.bits[i] = if r#if == Bit::One { then } else { r#else };
+    }
+    result
+}
+
+impl<const L: usize> BitXor for Word<L> {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        let mut result = Self::zero();
+        for i in 0..L {
+            result.bits[i] = match (self.bits[i], rhs.bits[i]) {
+                (Bit::Zero, Bit::Zero) | (Bit::One, Bit::One) => Bit::Zero,
+                (Bit::One, Bit::Zero) | (Bit::Zero, Bit::One) => Bit::One,
+            };
+        }
+        result
+    }
+}
+
+impl<const L: usize> Add for Word<L> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut result = Self::zero();
+        for i in 0..L {
+            result.bits[i] = self.bits[i] + rhs.bits[i];
+        }
+        result
+    }
+}

--- a/sha-reference/src/word.rs
+++ b/sha-reference/src/word.rs
@@ -37,7 +37,7 @@ impl<const L: usize> Word<L> {
     pub fn right_rotation(&self, n: usize) -> Self {
         let mut result = Self::zero();
         for i in 0..L {
-            result[i] = self[(i + L - n) % L];
+            result[i] = self[(i + n * L - n) % L];
         }
         result
     }
@@ -48,6 +48,12 @@ impl<const L: usize> Word<L> {
 
     pub fn rot_1(&self) -> Self {
         self.right_rotation(6) ^ self.right_rotation(11) ^ self.right_rotation(25)
+    }
+}
+
+impl<const L: usize> From<[Bit; L]> for Word<L> {
+    fn from(bits: [Bit; L]) -> Self {
+        Self { bits }
     }
 }
 

--- a/sha-reference/src/word.rs
+++ b/sha-reference/src/word.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use std::ops::{Add, BitXor};
+use std::ops::{Add, BitXor, Index, IndexMut};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum Bit {
@@ -35,7 +35,7 @@ impl<const L: usize> Word<L> {
     pub fn right_rotation(&self, n: usize) -> Self {
         let mut result = Self::zero();
         for i in 0..L {
-            result.bits[i] = self.bits[(i + L - n) % L];
+            result[i] = self[(i + L - n) % L];
         }
         result
     }
@@ -52,7 +52,7 @@ impl<const L: usize> Word<L> {
 pub fn majority<const L: usize>(a: &Word<L>, b: &Word<L>, c: &Word<L>) -> Word<L> {
     let mut result = Word::zero();
     for i in 0..L {
-        result.bits[i] = match (a.bits[i], b.bits[i], c.bits[i]) {
+        result[i] = match (a[i], b[i], c[i]) {
             (Bit::Zero, Bit::Zero, Bit::Zero)
             | (Bit::Zero, Bit::Zero, Bit::One)
             | (Bit::Zero, Bit::One, Bit::Zero)
@@ -66,8 +66,8 @@ pub fn majority<const L: usize>(a: &Word<L>, b: &Word<L>, c: &Word<L>) -> Word<L
 pub fn choose<const L: usize>(a: &Word<L>, b: &Word<L>, c: &Word<L>) -> Word<L> {
     let mut result = Word::zero();
     for i in 0..L {
-        let (r#if, then, r#else) = (a.bits[i], b.bits[i], c.bits[i]);
-        result.bits[i] = if r#if == Bit::One { then } else { r#else };
+        let (r#if, then, r#else) = (a[i], b[i], c[i]);
+        result[i] = if r#if == Bit::One { then } else { r#else };
     }
     result
 }
@@ -78,7 +78,7 @@ impl<const L: usize> BitXor for Word<L> {
     fn bitxor(self, rhs: Self) -> Self::Output {
         let mut result = Self::zero();
         for i in 0..L {
-            result.bits[i] = match (self.bits[i], rhs.bits[i]) {
+            result[i] = match (self[i], rhs[i]) {
                 (Bit::Zero, Bit::Zero) | (Bit::One, Bit::One) => Bit::Zero,
                 (Bit::One, Bit::Zero) | (Bit::Zero, Bit::One) => Bit::One,
             };
@@ -93,8 +93,22 @@ impl<const L: usize> Add for Word<L> {
     fn add(self, rhs: Self) -> Self::Output {
         let mut result = Self::zero();
         for i in 0..L {
-            result.bits[i] = self.bits[i] + rhs.bits[i];
+            result[i] = self[i] + rhs[i];
         }
         result
+    }
+}
+
+impl<const L: usize> Index<usize> for Word<L> {
+    type Output = Bit;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.bits[index]
+    }
+}
+
+impl<const L: usize> IndexMut<usize> for Word<L> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.bits[index]
     }
 }


### PR DESCRIPTION
In order to be able to verify parts of the circuit and validate intermediate steps, we add a 'reference' implementation of SHA hasing algorithm. Currently, it doesn't support `w` and `k` auxiliary vectors (for simplicity).